### PR TITLE
Retry when connecting to postgres fails

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - case-insensitive
 - uuid
 - psqueues
+- retry
 # Development
 - rapid
 # Logging

--- a/src/Tuttifrutti/Persist.hs
+++ b/src/Tuttifrutti/Persist.hs
@@ -8,7 +8,10 @@ module Tuttifrutti.Persist
 
 import           Tuttifrutti.Prelude
 
+import           Control.Monad.Catch                 (Handler (..))
 import qualified Control.Monad.Logger                as MonadLogger
+import           Control.Retry                       (RetryPolicy)
+import qualified Control.Retry                       as Retry
 import qualified Data.Has                            as Has
 import           Data.Pool                           (Pool)
 import qualified Data.Pool                           as Pool
@@ -24,13 +27,14 @@ import qualified Database.PostgreSQL.Simple          as PG
 import qualified System.Envy                         as Envy
 import qualified System.Log.FastLogger               as FastLogger
 
+import qualified GHC.IO.Exception                    as Exception
 import qualified Tuttifrutti.Log                     as Log
 import qualified Tuttifrutti.Log.Handle              as Log
 
 type MonadPersist env m =
   (MonadReader env m, Has Handle env, MonadUnliftIO m, MonadIO m, Log.MonadLog env m)
 
-newtype Handle = Handle { unHandle :: Pool SqlBackend }
+newtype Handle = Handle { handlePool :: Pool SqlBackend }
 
 -- | Read from environment vars all the parameters to make a ConnectInfo.
 --   The variable name to pass the password in needs to be provided.
@@ -43,17 +47,48 @@ getConnectInfo passwordEnvVar = liftIO $ Envy.runEnv $ do
   connectPassword <- Envy.env passwordEnvVar
   pure PG.ConnectInfo{..}
 
+defaultRetryPolicy :: RetryPolicy
+defaultRetryPolicy =
+  -- exponential backoff starting at 0.1 second
+  Retry.exponentialBackoff (round @Double 0.1e6)
+    -- with overall timeout of 1 minute
+    & Retry.limitRetriesByCumulativeDelay (round @Double 60e6)
+
 createConnectionPool :: Log.Handle -> PG.ConnectInfo -> IO (Pool SqlBackend)
 createConnectionPool logHandle connectInfo = do
   idleTimeout <- hush <$> do Envy.runEnv $ Envy.env "POSTGRES_POOL_IDLE_TIMEOUT"
   stripesAmount <- hush <$> do Envy.runEnv $ Envy.env "POSTGRES_POOL_STRIPES"
   connectionAmount <- hush <$> do Envy.runEnv $ Envy.env "POSTGRES_POOL_CONNECTIONS"
-  Pool.createPool
-    (Persist.openSimpleConn (logFunc logHandle) =<< PG.connect connectInfo)
-    Persist.close'
+  Pool.createPool connect disconnect
     (fromMaybe 1 stripesAmount)
     (maybe 600 fromInteger idleTimeout)
     (fromMaybe 10 connectionAmount)
+  where
+    connect =
+      Retry.recovering defaultRetryPolicy handlers $ \Retry.RetryStatus{..} -> do
+        when (rsIterNumber > 0) $ do
+          with logHandle $ do
+            Log.logInfo "Retrying to connect to database (${iter_number})"
+              [ "iter_number" .= rsIterNumber
+              , "cumulative_delay" .= rsCumulativeDelay
+              , "previous_delay" .= rsPreviousDelay
+              ]
+        Persist.openSimpleConn (logFunc logHandle) =<< PG.connect connectInfo
+    handlers =
+      [ \_retryStatus -> Handler $ \Exception.IOError{..} -> do
+          with logHandle $ do
+            Log.logError "An error occurred in ${location} when connecting to postgres."
+              [ "type" .= show ioe_type
+              , "location" .= ioe_location
+              , "description" .= ioe_description
+              , "errno" .= fmap show ioe_errno
+              , "filename" .= ioe_filename
+              , "handle" .= fmap show ioe_handle
+              ]
+          -- retry only if the error was raised by libpq
+          pure $ ioe_location == "libpq"
+      ]
+    disconnect = Persist.close'
 
 -- | Create a Handle for the Postgres Pool
 postgresHandle :: Log.Handle -> PG.ConnectInfo -> Migration -> IO Handle
@@ -97,7 +132,7 @@ logFunc logHandle _loc _source level msg = do
     payload = [ "query" .= decodeUtf8 (FastLogger.fromLogStr msg) ]
 
 closeHandle :: Handle -> IO ()
-closeHandle = Pool.destroyAllResources . unHandle
+closeHandle = Pool.destroyAllResources . handlePool
 
 -- | Our type synonym for environment that allows accessing 'SqlBackend'.
 type QueryT m = ReaderT SqlBackend m
@@ -105,12 +140,12 @@ type QueryT m = ReaderT SqlBackend m
 -- | Run a query in a transaction.
 transact :: (MonadPersist env m) => QueryT m a -> m a
 transact m = do
-  pool <- asks (unHandle . Has.getter)
+  Handle{..} <- asks Has.getter
   logHandle <- asks Has.getter
   runSqlPool
     -- we update the logging function to use current log handle
     (setLogFunc logHandle m)
-    pool
+    handlePool
   where
     setLogFunc logHandle =
       local $ \conn -> conn


### PR DESCRIPTION
We are regularly getting errors in production that look like:

```
*** Exception: libpq: failed (could not connect to server: Connection refused
        Is the server running on host "localhost" (::1) and accepting
        TCP/IP connections on port 5432?
```

Now we would retry in such events. This however wouldn't retry in
cases when an already opened connection becomes broken.