### PR TITLE
Add Tuttifrutti.Pool

### DIFF
--- a/src/Tuttifrutti/Pool.hs
+++ b/src/Tuttifrutti/Pool.hs
@@ -3,8 +3,8 @@ module Tuttifrutti.Pool
   , module Data.Pool
   ) where
 
-import           Data.Time           (NominalDiffTime)
 import           Tuttifrutti.Prelude
+import           Tuttifrutti.Time    (NominalDiffTime, nominalMinute)
 
 import           Data.Pool           hiding (createPool, withResource)
 import qualified Data.Pool           as Data.Pool
@@ -17,6 +17,13 @@ data Config = Config
     -- ^ maximum number of resources to keep open per stripe
   , configResourcesMax  :: Int
   } deriving (Show, Eq, Ord)
+
+defaultConfig :: Config
+defaultConfig = Config
+  { configStripesAmount = 1
+  , configUnusedTimeout = 10 * nominalMinute
+  , configResourcesMax  = 10
+  }
 
 -- | Same as 'Data.Pool.createPool' but takes nicer 'Config' type.
 createPool

--- a/src/Tuttifrutti/Pool.hs
+++ b/src/Tuttifrutti/Pool.hs
@@ -1,0 +1,39 @@
+module Tuttifrutti.Pool
+  ( module Tuttifrutti.Pool
+  , module Data.Pool
+  ) where
+
+import           Data.Time           (NominalDiffTime)
+import           Tuttifrutti.Prelude
+
+import           Data.Pool           hiding (createPool, withResource)
+import qualified Data.Pool           as Data.Pool
+
+data Config = Config
+  { -- ^ amount of stripes (distinct sub-pools) to maintain
+    configStripesAmount :: Int
+    -- ^ amount of time for which an unused resource is kept open
+  , configUnusedTimeout :: NominalDiffTime
+    -- ^ maximum number of resources to keep open per stripe
+  , configResourcesMax  :: Int
+  } deriving (Show, Eq, Ord)
+
+-- | Same as 'Data.Pool.createPool' but takes nicer 'Config' type.
+createPool
+  :: MonadIO m
+  => IO a         -- ^ action to create the resource
+  -> (a -> IO ()) -- ^ action to destroy the resource
+  -> Config
+  -> m (Pool a)
+createPool create destroy Config{..} =
+  liftIO $ Data.Pool.createPool
+    create destroy
+    configStripesAmount
+    configUnusedTimeout
+    configResourcesMax
+
+-- | Same as 'Data.Pool.withResource' but uses 'MonadUnliftIO'.
+withResource :: MonadUnliftIO m => Pool a -> (a -> m b) -> m b
+withResource pool action =
+  withRunInIO $ \runInIO -> Data.Pool.withResource pool $ runInIO . action
+

--- a/src/Tuttifrutti/Time.hs
+++ b/src/Tuttifrutti/Time.hs
@@ -7,6 +7,7 @@ module Tuttifrutti.Time
   , isToday
   , localFakeTime
   , localFrozenTime
+  , Time.NominalDiffTime
   , nominalDay
   , nominalHour
   , nominalMinute
@@ -16,8 +17,8 @@ module Tuttifrutti.Time
 import           Tuttifrutti.Prelude
 
 import qualified Data.Has                as Has
-import qualified RIO.Time                as Time
 import           Data.Time.Clock         (nominalDay)
+import qualified RIO.Time                as Time
 
 import           Tuttifrutti.Time.Handle
 


### PR DESCRIPTION
A wraper module around `Data.Pool` to fix some of its inconviniences.
The main aim here is to make creating resource pools nice and easy
so that other modules don't have to provide convinience functions
for creating pools, they'll just provide functions to allocate/release
their resources and the caller will have to create the pool with
desired configuration.