### PR TITLE
Increase timeout for connection retry policy

### DIFF
--- a/src/Tuttifrutti/Postgres.hs
+++ b/src/Tuttifrutti/Postgres.hs
@@ -26,8 +26,8 @@ defaultRetryPolicy :: RetryPolicy
 defaultRetryPolicy =
   -- exponential backoff starting at 0.1 second
   Retry.exponentialBackoff (round @Double 0.1e6)
-    -- with overall timeout of 1 minute
-    & Retry.limitRetriesByCumulativeDelay (round @Double 60e6)
+    -- with overall timeout of 10 minutes
+    & Retry.limitRetriesByCumulativeDelay (round @Double 60e7)
 
 type MonadPostgres env m =
   ( MonadReader env m


### PR DESCRIPTION
To 10 mins as Google Cloud guidelines advise [here](https://cloud.google.com/sql/docs/postgres/best-practices):

> The application should attempt to reconnect to the database, preferably using exponential backoff, for at least 10 minutes to ensure the application will resume operation after a maintenance event.