### PR TITLE
Add pattern for finding max-age=0 in cache control header

### DIFF
--- a/src/Tuttifrutti/Http/Header.hs
+++ b/src/Tuttifrutti/Http/Header.hs
@@ -27,6 +27,9 @@ pattern MaxAge = "max-age"
 pattern MaxAge0 :: (CI ByteString, Maybe ByteString)
 pattern MaxAge0 = ("max-age", Just "0")
 
+pattern InvalidateCache :: Maybe CacheControl
+pattern InvalidateCache <- ((maybe False (elem MaxAge0 . cacheControlDirectives)) -> True)
+
 instance FromHttpApiData CacheControl where
   parseHeader = first Text.pack . Atto.parseOnly pCacheControl
   parseQueryParam = first Text.pack . Atto.parseOnly pCacheControl . Text.encodeUtf8


### PR DESCRIPTION
So that we can conveniently pattern match when getting a `Maybe CacheControl`:

```haskell
case maybeCacheControl of
  InvalidateCache -> ...
  ...
```