### PR TITLE
Add servant failure pattern

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -77,6 +77,7 @@ dependencies:
 - servant
 - servant-server
 - servant-client
+- servant-client-core
 - servant-swagger
 - swagger2
 - path-pieces

--- a/src/Tuttifrutti/Servant.hs
+++ b/src/Tuttifrutti/Servant.hs
@@ -131,6 +131,6 @@ instance (HasServer api context, MimeUnrender JSON a, FromJSON a, ToSchema a)
         Error.servantErrResponse
           $ Error.errorResponse @415 @"unsupported_media_type" emptyRecord
 
--- | Matches a ClientError by a HTTP status code, returning the response body
+-- | Matches a ClientError.FailureResponse by HTTP status code, returning the response body
 pattern Failure :: Int -> LByteString.ByteString -> Servant.ClientError
 pattern Failure status responseBody <- Servant.FailureResponse _ Servant.Response { responseStatusCode = Status { statusCode = status }, responseBody }

--- a/src/Tuttifrutti/Servant.hs
+++ b/src/Tuttifrutti/Servant.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedLists  #-}
+{-# LANGUAGE PatternSynonyms  #-}
 -- | Tuttifrutti's adapter to servant.
 --
 --   As it is today, servant is very extensible, but not very configurable.
@@ -30,21 +31,25 @@ module Tuttifrutti.Servant
 
 import           Tuttifrutti.Prelude
 
-import qualified Data.ByteString.Lazy                       as LByteString
-import           Data.Swagger                               as Swagger
-import qualified Data.Text                                  as Text
-import qualified Network.HTTP.Types.Header                  as Http
-import qualified Network.Wai                                as Wai
-import           Servant.Swagger                            as Swagger
+import qualified Data.ByteString.Lazy              as LByteString
+import           Data.Swagger                      as Swagger
+import qualified Data.Text                         as Text
+import           Network.HTTP.Types                (Status (..))
+import qualified Network.HTTP.Types.Header         as Http
+import qualified Network.Wai                       as Wai
+import           Servant.Swagger                   as Swagger
 
-import           Data.Extensible                            (emptyRecord, (<:), (@=))
-import           Servant                                    as Servant hiding (JSON)
+import           Data.Extensible                   (emptyRecord, (<:), (@=))
+import           Servant                           as Servant hiding (JSON)
 import qualified Servant
-import           Servant.API.ContentTypes                   (canHandleCTypeH)
-import           Servant.Server.Internal.Delayed            (addBodyCheck)
-import           Servant.Server.Internal.DelayedIO          (delayedFailFatal, withRequest)
+import           Servant.API.ContentTypes          (canHandleCTypeH)
+import qualified Servant.Client.Core               as Servant
+import           Servant.Server.Internal.Delayed   (addBodyCheck)
+import           Servant.Server.Internal.DelayedIO (delayedFailFatal,
+                                                    withRequest)
 
-import qualified Tuttifrutti.Error as Error
+
+import qualified Tuttifrutti.Error                 as Error
 
 
 -- | This 'JSON' type shadows the one from servant. It's purpose is to label 'application/json'
@@ -125,3 +130,7 @@ instance (HasServer api context, MimeUnrender JSON a, FromJSON a, ToSchema a)
       mediaTypeError =
         Error.servantErrResponse
           $ Error.errorResponse @415 @"unsupported_media_type" emptyRecord
+
+-- | Matches a ClientError by a HTTP status code, returning the response body
+pattern ServantError :: Int -> LByteString.ByteString -> Servant.ClientError
+pattern ServantError status responseBody <- Servant.FailureResponse _ Servant.Response { responseStatusCode = Status { statusCode = status }, responseBody }

--- a/src/Tuttifrutti/Servant.hs
+++ b/src/Tuttifrutti/Servant.hs
@@ -132,5 +132,5 @@ instance (HasServer api context, MimeUnrender JSON a, FromJSON a, ToSchema a)
           $ Error.errorResponse @415 @"unsupported_media_type" emptyRecord
 
 -- | Matches a ClientError by a HTTP status code, returning the response body
-pattern ServantError :: Int -> LByteString.ByteString -> Servant.ClientError
-pattern ServantError status responseBody <- Servant.FailureResponse _ Servant.Response { responseStatusCode = Status { statusCode = status }, responseBody }
+pattern Failure :: Int -> LByteString.ByteString -> Servant.ClientError
+pattern Failure status responseBody <- Servant.FailureResponse _ Servant.Response { responseStatusCode = Status { statusCode = status }, responseBody }

--- a/tuttifrutti.cabal
+++ b/tuttifrutti.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7b01d2d9e75e5e14f280e0186cd6722b0f45f0473f62c2d61f1385da659af330
+-- hash: 20eb63ea2e43dafacaa8554393f961435dc26d3b80d817fb8b875d4a295a0087
 
 name:           tuttifrutti
 version:        0.1.0.0
@@ -125,6 +125,7 @@ library
     , semialign
     , servant
     , servant-client
+    , servant-client-core
     , servant-server
     , servant-swagger
     , smtp-mail
@@ -257,6 +258,7 @@ test-suite spec
     , semialign
     , servant
     , servant-client
+    , servant-client-core
     , servant-server
     , servant-swagger
     , smtp-mail


### PR DESCRIPTION
Makes pattern matching Servant FailureResponses nicer.
```haskell
-- From
case res of
  FailureResponse _request (Response { responseStatusCode = Status { statusCode = 404 }, responseBody }) -> ...

-- To
case res of
  Servant.Failure 404 responseBody -> ...

```