### PR TITLE
Tag unknown paper codes and add custom paper code encode method

### DIFF
--- a/src/Tuttifrutti/Models/PaperCode.hs
+++ b/src/Tuttifrutti/Models/PaperCode.hs
@@ -3,8 +3,9 @@ module Tuttifrutti.Models.PaperCode where
 
 import           Tuttifrutti.Prelude
 
+import           Data.Aeson          (Value (String), withText)
 import qualified Data.Text           as Text
-import           Data.Unjson
+import           Data.Unjson         (Unjson (..), unjsonAeson)
 import           Database.Persist.TH (derivePersistField)
 
 data PaperCode
@@ -12,11 +13,16 @@ data PaperCode
   | ON
   | VN
   | HT
+  | UnknownPaperCode Text
   deriving (Show, Eq, Generic, Read, Data, Ord)
 derivePersistField "PaperCode"
 
-instance FromJSON PaperCode
-instance ToJSON PaperCode
+instance FromJSON PaperCode where
+  parseJSON = withText "PaperCode" (pure . toPaperCode)
+instance ToJSON PaperCode where
+  toJSON c = case c of
+    UnknownPaperCode p -> String p
+    _                  -> String $ tshow c
 instance Unjson PaperCode where
   unjsonDef = unjsonAeson
 
@@ -29,4 +35,4 @@ toPaperCode paperCodeText =
     "ÖNY" -> ON
     "VN"  -> VN
     "HT"  -> HT
-    _     -> HBL
+    p     -> UnknownPaperCode p

--- a/src/Tuttifrutti/Models/PaperCode.hs
+++ b/src/Tuttifrutti/Models/PaperCode.hs
@@ -20,9 +20,7 @@ derivePersistField "PaperCode"
 instance FromJSON PaperCode where
   parseJSON = withText "PaperCode" (pure . toPaperCode)
 instance ToJSON PaperCode where
-  toJSON c = case c of
-    UnknownPaperCode p -> String p
-    _                  -> String $ tshow c
+  toJSON = String . fromPaperCode
 instance Unjson PaperCode where
   unjsonDef = unjsonAeson
 
@@ -36,3 +34,9 @@ toPaperCode paperCodeText =
     "VN"  -> VN
     "HT"  -> HT
     p     -> UnknownPaperCode p
+
+fromPaperCode :: PaperCode -> Text
+fromPaperCode paperCode =
+  case paperCode of
+    UnknownPaperCode p -> p
+    _                  -> tshow paperCode


### PR DESCRIPTION
* Override FromJSON, ToJSON instances
* Fix Unjson instance to tag unrecognized paper codes and account
  for alternate spellings