### PR TITLE
Add set function to storage Handle for updates which don't use old value

### DIFF
--- a/src/Tuttifrutti/Cache/Storage/InMemory.hs
+++ b/src/Tuttifrutti/Cache/Storage/InMemory.hs
@@ -32,6 +32,7 @@ newHandle capacity = do
   pure $ Storage.Handle
     { Storage.alter = \f k ->
         stateTVar var (alter f k)
+    , Storage.set = Nothing
     , Storage.dropRange = \p ->
         stateTVar var $ ((),) . dropRange p
     }

--- a/src/Tuttifrutti/Cache/Storage/InMemoryRef.hs
+++ b/src/Tuttifrutti/Cache/Storage/InMemoryRef.hs
@@ -27,6 +27,7 @@ newHandle capacity = do
   pure $ Storage.Handle
     { Storage.alter = \f k ->
         stateTVar var (alter f k)
+    , Storage.set = Nothing
     , Storage.dropRange = \p ->
         stateTVar var $ ((),) . dropRange p
     }


### PR DESCRIPTION
The in memory cache implementations ought to be fast enough with using the existing alter implementations for everything so I made defining `set` optional.