### PR TITLE
Allow scandinavic letters on the left-hand side of '@' in email addresses

### DIFF
--- a/src/Tuttifrutti/Models/EmailAddress.hs
+++ b/src/Tuttifrutti/Models/EmailAddress.hs
@@ -46,4 +46,4 @@ isEmailAddressValid (EmailAddress email) = matchTest (makeRegex (Text.unpack ema
 
 -- | From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#Validation
 emailRegex :: Text
-emailRegex = "^[a-zA-Z0-9.!#$%&'*+\\\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+emailRegex = "^[a-zåäöA-ZÅÄÖ0-9.!#$%&'*+\\\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"


### PR DESCRIPTION
Relax the email validation regex